### PR TITLE
Update ModItems.java

### DIFF
--- a/src/main/java/io/github/cadiboo/examplemod/init/ModItems.java
+++ b/src/main/java/io/github/cadiboo/examplemod/init/ModItems.java
@@ -24,6 +24,6 @@ public final class ModItems {
 
 	// This is a very simple Item. It has no special properties except for being on our creative tab.
 	public static final RegistryObject<Item> EXAMPLE_CRYSTAL = ITEMS.register("example_crystal", () -> new Item(new Item.Properties().group(ModItemGroups.MOD_ITEM_GROUP)));
-	public static final RegistryObject<ModdedSpawnEggItem> WILD_BOAR_SPAWN_EGG = ITEMS.register("wild_boar_spawn_egg", () -> new ModdedSpawnEggItem(ModEntityTypes.WILD_BOAR, 0xF0A5A2, 0xA9672B, new Item.Properties().group(ModItemGroups.MOD_ITEM_GROUP)));
+	public static final RegistryObject<ModdedSpawnEggItem> WILD_BOAR_SPAWN_EGG = ITEMS.register("wild_boar_spawn_egg", () -> new ModdedSpawnEggItem(ModEntityTypes.WILD_BOAR.get(), 0xF0A5A2, 0xA9672B, new Item.Properties().group(ModItemGroups.MOD_ITEM_GROUP)));
 
 }


### PR DESCRIPTION
Since ModEntityTypes.WILD_BOAR is of type RegistryObject<EntityType<WildBoarEntity>>. I thought that maybe it was incorrect because .get() need to get called in order to return the EntityType<WildBoarEntity>.